### PR TITLE
Adding support for multiple validations 

### DIFF
--- a/luceneValidator.js
+++ b/luceneValidator.js
@@ -3,19 +3,21 @@ define(['underscore'], function(_){
 
         function removeEscapes(query){
             return query.replace(/\\./g, "");
-        },
+        }
 
         function checkAllowedCharacters(query){
             if(/[^a-zA-Z0-9_+\-:.()\"*?&|!{}\[\]\^~\\@#\/$%'= ]/.test(query)){
                 return "The allowed characters are a-z A-Z 0-9.  _ + - : () \" & * ? | ! {} [ ] ^ ~ \\ @ = # % $ ' /.";
             }
-        },
+            return false;
+        }
 
         function checkAsterisk(query){
             if(/^[\*]*$|[\s]\*|^\*[^\s]/.test(query)){
                 return "The wildcard (*) character must be preceded by at least one alphabet or number.";
             }
-        },
+            return false;
+        }
 
         function checkAmpersands(query){
             // NB: doesn't handle term1 && term2 && term3 in Firebird 0.7
@@ -26,32 +28,37 @@ define(['underscore'], function(_){
                     return "Queries containing the special characters && must be in the form: term1 && term2.";
                 }
             }
-        },
+            return false;
+        }
 
         function checkCaret(query){
             if(/[^\\]\^([^\s]*[^0-9.]+)|[^\\]\^$/.test(query)){
                 return "The caret (^) character must be preceded by alphanumeric characters and followed by numbers.";
             }
-        },
+            return false;
+        }
 
         function checkTilde(query){
             if(/[^\\]~[^\s]*[^0-9\s]+/.test(query)){
                 return "The tilde (~) character must be preceded by alphanumeric characters and followed by numbers.";
             }
-        },
+            return false;
+        }
 
         function checkExclamationMark(query){
             // NB: doesn't handle term1 ! term2 ! term3 or term1 !term2
             if(!/^[^!]*$|^([a-zA-Z0-9_+\-:.()\"*?&|!{}\[\]\^~\\@#\/$%'=]+( ! )?[a-zA-Z0-9_+\-:.()\"*?&|!{}\[\]\^~\\@#\/$%'=]+[ ]*)+$/.test(query)){
                 return "Queries containing the special character ! must be in the form: term1 ! term2.";
             }
-        },
+            return false;
+        }
 
         function checkQuestionMark(query){
             if(/^(\?)|([^a-zA-Z0-9_+\-:.()\"*?&|!{}\[\]\^~\\@#\/$%'=]\?+)/.test(query)){
                 return "The question mark (?) character must be preceded by at least one alphabet or number.";
             }
-        },
+            return false;
+        }
 
         function checkParentheses(query){
             var matchLeft = query.match(/[(]/g),
@@ -60,7 +67,7 @@ define(['underscore'], function(_){
                 countRight = matchRight ? matchRight.length : 0;
 
             if(!matchLeft && !matchRight){
-                return;
+                return false;
             }
 
             if(matchLeft && !matchRight || matchRight && !matchLeft){
@@ -74,17 +81,20 @@ define(['underscore'], function(_){
             if(/\(\)/.test(query)){
                 return"Parentheses must contain at least one character.";
             }
-        },
+
+            return false;
+        }
 
         function checkPlusMinus(query){
             if(!/^[^\n+\-]*$|^([+\-]?[a-zA-Z0-9_:.()\"*?&|!{}\[\]\^~\\@#\/$%'=]+[ ]?)+$/.test(query)){
                 return "'+' and '-' modifiers must be followed by at least one alphabet or number.";
             }
-        },
+            return false;
+        }
 
         function checkANDORNOT(query){
             if(!/AND|OR|NOT/.test(query)){
-                return;
+                return false;
             }
 
             if(!/^([a-zA-Z0-9_+\-:.()\"*?&|!{}\[\]\^~\\@\/#$%'=]+\s*((AND )|(OR )|(AND NOT )|(NOT ))?[a-zA-Z0-9_+\-:.()\"*?&|!{}\[\]\^~\\@\/#$%'=]+[ ]*)+$/.test(query)){
@@ -94,14 +104,15 @@ define(['underscore'], function(_){
             if(/^((AND )|(OR )|(AND NOT )|(NOT ))|((AND)|(OR)|(AND NOT )|(NOT))[ ]*$/.test(query)){
                 return "Queries containing AND/OR/NOT must be in the form: term1 AND|OR|NOT|AND NOT term2";
             }
-        },
+            return false;
+        }
 
         function checkQuotes(query){
             var matches = query.match(/\"/g),
                 matchCount;
 
             if(!matches){
-                return;
+                return false;
             }
 
             matchCount = matches.length;
@@ -113,17 +124,18 @@ define(['underscore'], function(_){
             if(/""/.test(query)){
                 return "Quotes must contain at least one character.";
             }
-        },
+        }
 
         function checkColon(query){
             if(/[^\\\s]:[\s]|[^\\\s]:$|[\s][^\\]?:|^[^\\\s]?:/.test(query)){
                 return "Field declarations (:) must be preceded by at least one alphabet or number and followed by at least one alphabet or number.";
             }
-        },
+            return false;
+        }
 
         function validateAll(query){
             if(!query){
-                return;
+                return false;
             }
 
             query = removeEscapes(query);

--- a/luceneValidator.js
+++ b/luceneValidator.js
@@ -1,24 +1,23 @@
 "use strict";
 define(['underscore'], function(_){
 
-    return {
-        removeEscapes: function(query){
+        function removeEscapes(query){
             return query.replace(/\\./g, "");
         },
 
-        checkAllowedCharacters: function(query){
+        function checkAllowedCharacters(query){
             if(/[^a-zA-Z0-9_+\-:.()\"*?&|!{}\[\]\^~\\@#\/$%'= ]/.test(query)){
                 return "The allowed characters are a-z A-Z 0-9.  _ + - : () \" & * ? | ! {} [ ] ^ ~ \\ @ = # % $ ' /.";
             }
         },
 
-        checkAsterisk: function(query){
+        function checkAsterisk(query){
             if(/^[\*]*$|[\s]\*|^\*[^\s]/.test(query)){
                 return "The wildcard (*) character must be preceded by at least one alphabet or number.";
             }
         },
 
-        checkAmpersands: function(query){
+        function checkAmpersands(query){
             // NB: doesn't handle term1 && term2 && term3 in Firebird 0.7
             var matches = query.match(/[&]{2}/);
             if(matches && matches.length > 0){
@@ -29,32 +28,32 @@ define(['underscore'], function(_){
             }
         },
 
-        checkCaret: function(query){
+        function checkCaret(query){
             if(/[^\\]\^([^\s]*[^0-9.]+)|[^\\]\^$/.test(query)){
                 return "The caret (^) character must be preceded by alphanumeric characters and followed by numbers.";
             }
         },
 
-        checkTilde: function(query){
+        function checkTilde(query){
             if(/[^\\]~[^\s]*[^0-9\s]+/.test(query)){
                 return "The tilde (~) character must be preceded by alphanumeric characters and followed by numbers.";
             }
         },
 
-        checkExclamationMark: function(query){
+        function checkExclamationMark(query){
             // NB: doesn't handle term1 ! term2 ! term3 or term1 !term2
             if(!/^[^!]*$|^([a-zA-Z0-9_+\-:.()\"*?&|!{}\[\]\^~\\@#\/$%'=]+( ! )?[a-zA-Z0-9_+\-:.()\"*?&|!{}\[\]\^~\\@#\/$%'=]+[ ]*)+$/.test(query)){
                 return "Queries containing the special character ! must be in the form: term1 ! term2.";
             }
         },
 
-        checkQuestionMark: function(query){
+        function checkQuestionMark(query){
             if(/^(\?)|([^a-zA-Z0-9_+\-:.()\"*?&|!{}\[\]\^~\\@#\/$%'=]\?+)/.test(query)){
                 return "The question mark (?) character must be preceded by at least one alphabet or number.";
             }
         },
 
-        checkParentheses: function(query){
+        function checkParentheses(query){
             var matchLeft = query.match(/[(]/g),
                 matchRight = query.match(/[)]/g),
                 countLeft = matchLeft ? matchLeft.length : 0,
@@ -77,13 +76,13 @@ define(['underscore'], function(_){
             }
         },
 
-        checkPlusMinus: function(query){
+        function checkPlusMinus(query){
             if(!/^[^\n+\-]*$|^([+\-]?[a-zA-Z0-9_:.()\"*?&|!{}\[\]\^~\\@#\/$%'=]+[ ]?)+$/.test(query)){
                 return "'+' and '-' modifiers must be followed by at least one alphabet or number.";
             }
         },
 
-        checkANDORNOT: function(query){
+        function checkANDORNOT(query){
             if(!/AND|OR|NOT/.test(query)){
                 return;
             }
@@ -97,7 +96,7 @@ define(['underscore'], function(_){
             }
         },
 
-        checkQuotes: function(query){
+        function checkQuotes(query){
             var matches = query.match(/\"/g),
                 matchCount;
 
@@ -116,23 +115,23 @@ define(['underscore'], function(_){
             }
         },
 
-        checkColon: function(query){
+        function checkColon(query){
             if(/[^\\\s]:[\s]|[^\\\s]:$|[\s][^\\]?:|^[^\\\s]?:/.test(query)){
                 return "Field declarations (:) must be preceded by at least one alphabet or number and followed by at least one alphabet or number.";
             }
         },
 
-        doCheckLuceneQueryValue: function(query){
+        function validateAll(query){
             if(!query){
                 return;
             }
 
-            query = this.removeEscapes(query);
+            query = removeEscapes(query);
 
-            var tests = [this.checkAllowedCharacters,this.checkAsterisk,this.checkAmpersands,
-                            this.checkCaret,this.checkTilde,this.checkExclamationMark,
-                            this.checkQuestionMark,this.checkParentheses,this.checkPlusMinus,
-                            this.checkANDORNOT,this.checkQuotes,this.checkColon];
+            var tests = [checkAllowedCharacters,checkAsterisk,checkAmpersands,
+                            checkCaret,checkTilde,checkExclamationMark,
+                            checkQuestionMark,checkParentheses,checkPlusMinus,
+                            checkANDORNOT,checkQuotes,checkColon];
 
             var errors = _.chain(tests)
                 .map(function(test) { return test(query); })
@@ -141,6 +140,9 @@ define(['underscore'], function(_){
 
             return (errors.length > 0) ? errors : false;
         }
+
+    return {
+        doCheckLuceneQueryValue : validateAll
     };
 
 });

--- a/luceneValidator.js
+++ b/luceneValidator.js
@@ -1,5 +1,5 @@
 "use strict";
-define([], function(){
+define(['underscore'], function(_){
 
     return {
         removeEscapes: function(query){
@@ -129,18 +129,17 @@ define([], function(){
 
             query = this.removeEscapes(query);
 
-            var errorMsg,
-                tests = [this.checkAllowedCharacters,this.checkAsterisk,this.checkAmpersands,
+            var tests = [this.checkAllowedCharacters,this.checkAsterisk,this.checkAmpersands,
                             this.checkCaret,this.checkTilde,this.checkExclamationMark,
                             this.checkQuestionMark,this.checkParentheses,this.checkPlusMinus,
                             this.checkANDORNOT,this.checkQuotes,this.checkColon];
 
-            for (var i = tests.length - 1; i >= 0; i--) {
-                errorMsg = tests[i](query);
-                if(errorMsg){
-                    return errorMsg;
-                }
-            }
+            var errors = _.chain(tests)
+                .map(function(test) { return test(query); })
+                .where(function(r) { return r; })
+                .value();
+
+            return (errors.length > 0) ? errors : false;
         }
     };
 

--- a/luceneValidator.js
+++ b/luceneValidator.js
@@ -1,16 +1,7 @@
 "use strict";
 define([], function(){
 
-    // Makes wildcard queries case-insensitive if true.
-    // Refer to http://www.mail-archive.com/lucene-user@jakarta.apache.org/msg00646.html
-
-    var wildcardCaseInsensitive = true;
-
     return {
-        setWildcardCaseInsensitive: function(bool){
-            wildcardCaseInsensitive = bool;
-        },
-
         removeEscapes: function(query){
             return query.replace(/\\./g, "");
         },
@@ -148,18 +139,6 @@ define([], function(){
                 errorMsg = tests[i](query);
                 if(errorMsg){
                     return errorMsg;
-                }
-            }
-
-            if(wildcardCaseInsensitive){
-                if(query.indexOf("*") != -1){
-                    var j = query.indexOf(':');
-                    if(j == -1){
-                        query.value = query.toLowerCase();
-                    } else {
-                        // found a wildcard field search
-                        query.value = query.substring(0, j) + query.substring(j).toLowerCase();
-                    }
                 }
             }
         }


### PR DESCRIPTION
Again there is a lot going on here. I have separated it out a bit. Take what you like out of this or take nothing. I just wanted to share what I added to your module.
- Removed wildcard query modifier. Not a fan of this because it introduces a side-effect into the validation process. It feels like this concern should be elsewhere.
- Took an underscore dependency because apparently I can't do list processing without it. 
- Reduced the API surface area but only returning a hash with the one validation method. All other functions are now named. 
