### PR TITLE
Fixing words ending on OR etc "ACTUATOR"

### DIFF
--- a/luceneValidator.js
+++ b/luceneValidator.js
@@ -101,7 +101,7 @@ define([], function(){
                 return "Queries containing AND/OR/NOT must be in the form: term1 AND|OR|NOT|AND NOT term2";
             }
 
-            if(/^((AND )|(OR )|(AND NOT )|(NOT ))|((AND)|(OR)|(AND NOT )|(NOT))[ ]*$/.test(query)){
+            if(/^((AND )|(OR )|(AND NOT )|(NOT ))|((\bAND)|(\bOR)|(AND NOT )|(\bNOT))[ ]*$/.test(query)){
                 return "Queries containing AND/OR/NOT must be in the form: term1 AND|OR|NOT|AND NOT term2";
             }
         },


### PR DESCRIPTION
This addresses the issue with words ending on OR/AND/NOT. 

For example the validation would flag the words ACTUATOR, EXECUTOR NAND etc.